### PR TITLE
Improve web view controls with debug info

### DIFF
--- a/magos.py
+++ b/magos.py
@@ -545,7 +545,11 @@ class MainWindow(QMainWindow):
             layout.addWidget(placeholder)
             self.web_view = None
         
-        # Botón para recargar
+        # Botones para cargar y recargar
+
+        load_btn = QPushButton("Cargar Página")
+        load_btn.clicked.connect(self.load_web_view)
+        layout.addWidget(load_btn)
 
         reload_btn = QPushButton("Recargar Vista Web")
         reload_btn.clicked.connect(self.reload_web_view)
@@ -835,7 +839,9 @@ class MainWindow(QMainWindow):
             # La autenticación para la interfaz web se realiza mediante un token
             # obtenido al conectarse al radar. Construimos la URL de forma
             # robusta para evitar problemas con barras al final.
-            web_base = urljoin(self.radar_api.base_url + '/', 'webclient')
+            # Usamos trailing slash para prevenir errores "Cannot GET /webclient"
+            # en algunos servidores que esperan la ruta con '/' al final.
+            web_base = urljoin(self.radar_api.base_url + '/', 'webclient/')
             web_url = f"{web_base}?token={self.radar_api.token}"
 
             if DEBUG:
@@ -859,6 +865,13 @@ class MainWindow(QMainWindow):
             )
             print(f"DEBUG: {msg}")
             self.log_event(msg)
+            if ok and self.web_view:
+                def _log_html(html: str):
+                    snippet = html.replace("\n", " ")[:200]
+                    print(f"DEBUG: HTML inicial: {snippet}")
+                    self.log_event(f"HTML inicial: {snippet}")
+
+                self.web_view.page().toHtml(_log_html)
     
     def start_data_collection(self):
         """Inicia la recolección de datos"""


### PR DESCRIPTION
## Summary
- add a `Cargar Página` button to load the MAGOS web interface
- show the first portion of the page HTML when debug is enabled
- fix the web URL so `/webclient/` loads correctly

## Testing
- `python -m py_compile magos.py`


------
https://chatgpt.com/codex/tasks/task_e_6888f732d688832d87b1b813b768e3e7