### PR TITLE
Fix magos.py syntax error

### DIFF
--- a/magos.py
+++ b/magos.py
@@ -721,6 +721,10 @@ class MainWindow(QMainWindow):
 
         # Tab 1: Detecciones en tiempo real
         detections_tab = self.create_detections_tab()
+        tab_widget.addTab(detections_tab, "Detecciones")
+
+        # Tab 2: Configuración de filtros
+        filters_tab = self.create_filters_tab()
         tab_widget.addTab(filters_tab, "Filtros")
 
         # Tab 3: Estadísticas
@@ -1338,8 +1342,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main()detections_tab, "Detecciones")
-
-        # Tab 2: Configuración de filtros
-        filters_tab = self.create_filters_tab()
-        tab_widget.addTab(
+    main()


### PR DESCRIPTION
## Summary
- restore `create_data_panel` tab setup
- fix `__main__` block that caused a SyntaxError

## Testing
- `python -m py_compile magos.py`
- `python magos.py` *(fails: ModuleNotFoundError: No module named 'requests')*

------
https://chatgpt.com/codex/tasks/task_e_6889346a13f8832d99058f6ed86bbbf0